### PR TITLE
Node split

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -95,7 +95,8 @@ pub trait RPC<K, V> {
     fn find_value(&self, key: K) -> V;
     fn ping(&self) -> bool;
 }
-
+// KademNode represents the entire data struct of a node
+// Contained within is the route table for finding other nodes, and hash map to store the k, v pairs
 #[derive(Debug)]
 pub struct KademNode<K, V> {
     pub node_id: ByteString,
@@ -117,7 +118,8 @@ impl<K, V> KademNode<K, V> {
         }
     }
 }
-
+// Node represents a entity that is running a Kademlia DHT protocol
+// It can be uniquely identified by the node_id and has ip addr and port for UDP connection
 #[derive(Debug, Clone, Copy)]
 pub struct Node {
     pub node_id: ByteString,

--- a/src/node.rs
+++ b/src/node.rs
@@ -11,7 +11,7 @@ pub const ID_LENGTH: usize = 20;
 pub enum Bit {
     Zero,
     One,
-    None,
+    Root,
 }
 
 // 160 bit Node ID in tuple, 0 position is an array of bits, and 1 position is the size

--- a/src/node.rs
+++ b/src/node.rs
@@ -107,11 +107,12 @@ pub struct KademNode<K, V> {
 
 impl<K, V> KademNode<K, V> {
     pub fn new(ip_addr: IpAddr, port: u16) -> Self {
+        let node_id = ByteString::random_new();
         KademNode {
-            node_id: ByteString::random_new(),
+            node_id,
             ip_addr,
             port,
-            route_table: Some(RouteTable::empty_new()),
+            route_table: Some(RouteTable::empty_new(node_id.clone())),
             hash_map: Some(HashMap::new()),
         }
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -135,13 +135,13 @@ impl Vertex {
                             1 => {
                                 if !matches!(vert.bit, Bit::One) {
                                     split = false;
-                                    // Handle logic for pinging and replacing current k-bucket list
+                                    // TODO: Handle logic for pinging and replacing current k-bucket list
                                 }
                             }
                             0 => {
                                 if !matches!(vert.bit, Bit::Zero) {
                                     split = false;
-                                    // Handle logic for pinging and replacing current k-bucket list
+                                    // TODO: Handle logic for pinging and replacing current k-bucket list
                                 }
                             }
                             _ => {}
@@ -150,7 +150,7 @@ impl Vertex {
                     // End borrow
                 }
 
-                // If it is, proceed to splitting process
+                // If it is contained in the prefix, proceed to splitting process
                 if split {
                     // Split the k_bucket into two
                     let (left_vert, right_vert) = Vertex::split(vertex);
@@ -169,7 +169,7 @@ impl Vertex {
                         // End borrow
                     }
                     // Recursively trickle down once more to add the node
-                    Vertex::add_node(vertex, node, node_iter, &node_id, prefix_contained);
+                    Vertex::add_node(vertex, node, node_iter, &node_id, false);
                 }
             }
             // Recursive step: Vertex has no k_bucket
@@ -213,10 +213,6 @@ impl RouteTable {
 
     // Add vertex to the trie that contains k_bucket
     pub fn add_vertex() {}
-
-    pub fn contain_prefix(&self, node_id: [u8; ID_LENGTH]) -> bool {
-        true
-    }
 
     // Add a node to the k_bucket starting from the root of the trie
     pub fn add_node(&mut self, node: Node) {


### PR DESCRIPTION
- Added logic to split the node based on prefix of the node_id to be added.
> - When current bucket is full, the logic to replace one of the node is still to be implemented.